### PR TITLE
feat: add Welcome to the Jungle scraper support

### DIFF
--- a/jobspy/__init__.py
+++ b/jobspy/__init__.py
@@ -12,6 +12,7 @@ from jobspy.google import Google
 from jobspy.indeed import Indeed
 from jobspy.linkedin import LinkedIn
 from jobspy.naukri import Naukri
+from jobspy.wttj import Wttj
 from jobspy.model import JobType, Location, JobResponse, Country
 from jobspy.model import SalarySource, ScraperInput, Site
 from jobspy.util import (
@@ -64,6 +65,7 @@ def scrape_jobs(
         Site.BAYT: BaytScraper,
         Site.NAUKRI: Naukri,
         Site.BDJOBS: BDJobs,  # Add BDJobs to the scraper mapping
+        Site.WTTJ: Wttj,
     }
     set_logger_level(verbose)
     job_type = get_enum_from_value(job_type) if job_type else None
@@ -224,4 +226,5 @@ def scrape_jobs(
 # Add BDJobs to __all__
 __all__ = [
     "BDJobs",
+    "Wttj",
 ]

--- a/jobspy/exception.py
+++ b/jobspy/exception.py
@@ -43,3 +43,7 @@ class NaukriException(Exception):
 class BDJobsException(Exception):
     def __init__(self, message=None):
         super().__init__(message or "An error occurred with BDJobs")
+
+class WttjException(Exception):
+    def __init__(self, message=None):
+        super().__init__(message or "An error occurred with WTTJ")

--- a/jobspy/model.py
+++ b/jobspy/model.py
@@ -293,7 +293,7 @@ class Site(Enum):
     BAYT = "bayt"
     NAUKRI = "naukri"
     BDJOBS = "bdjobs"  # Add this line
-
+    WTTJ = "wttj"
 
 class SalarySource(Enum):
     DIRECT_DATA = "direct_data"

--- a/jobspy/wttj/__init__.py
+++ b/jobspy/wttj/__init__.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+import math
+import urllib.parse
+from datetime import datetime
+from jobspy.model import (
+    Scraper,
+    ScraperInput,
+    Site,
+    JobResponse,
+    JobPost,
+    Location,
+    JobType,
+)
+from jobspy.util import create_session, create_logger
+from jobspy.exception import WttjException
+
+def _map_wttj_job_type(wttj_type: str) -> list[JobType]:
+    if not wttj_type:
+        return []
+    wttj_type = wttj_type.lower()
+    mapping = {
+        "full_time": JobType.FULL_TIME,
+        "part_time": JobType.PART_TIME,
+        "internship": JobType.INTERNSHIP,
+        "apprenticeship": JobType.INTERNSHIP,
+        "contract": JobType.CONTRACT,
+        "temporary": JobType.TEMPORARY
+    }
+    job_type = mapping.get(wttj_type)
+    return [job_type] if job_type else []
+
+def _parse_date(date_str: str | None):
+    if not date_str:
+        return None
+    try:
+        return datetime.strptime(date_str.split("T")[0], "%Y-%m-%d").date()
+    except (ValueError, IndexError):
+        return None
+
+log = create_logger("Wttj")
+
+class Wttj(Scraper):
+    def __init__(
+        self, proxies: list[str] | str | None = None, ca_cert: str | None = None, user_agent: str | None = None
+    ):
+        """
+        Initializes the WTTJ Scraper
+        """
+        super().__init__(Site.WTTJ, proxies=proxies, ca_cert=ca_cert)
+        self.session = create_session(
+            proxies=self.proxies,
+            ca_cert=self.ca_cert,
+            is_tls=False,
+            has_retry=True,
+        )
+        if user_agent:
+            self.session.headers.update({"User-Agent": user_agent})
+
+    def scrape(self, scraper_input: ScraperInput) -> JobResponse:
+        """
+        Scrapes WTTJ for jobs using their public Algolia Search API backend.
+        """
+        job_list: list[JobPost] = []
+        seen_urls = set()  # Garantit l'unicité des offres sur l'ensemble du scraping
+        
+        url = "https://csekhvms53-dsn.algolia.net/1/indexes/wk_cms_jobs_production/query"
+        
+        page = 0 if not scraper_input.offset else math.floor(scraper_input.offset / 30)
+        max_pages = 30
+        
+        self.session.headers.update({
+            "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+            "Accept": "*/*",
+            "Accept-Language": "fr-FR,fr;q=0.9,en;q=0.8",
+            "Content-Type": "application/x-www-form-urlencoded",
+            "Origin": "https://www.welcometothejungle.com",
+            "Referer": "https://www.welcometothejungle.com/",
+            "x-algolia-application-id": "CSEKHVMS53",
+            "x-algolia-api-key": "4bd8f6215d0cc52b26430765769e65a0"
+        })
+        
+        while len(job_list) < scraper_input.results_wanted and page < max_pages:
+            log.info(f"Scraping page {page + 1} for WTTJ via Algolia API")
+            
+            search_query = scraper_input.search_term or ""
+            if scraper_input.location:
+                search_query = f"{search_query} {scraper_input.location}".strip()
+
+            query_str = f"query={urllib.parse.quote(search_query)}"
+            query_str += f"&page={page}"
+            query_str += f"&hitsPerPage={min(scraper_input.results_wanted - len(job_list), 30)}"
+
+            payload = f'{{"params":"{query_str}"}}'
+
+            try:
+                response = self.session.post(
+                    url,
+                    data=payload,
+                    timeout=scraper_input.request_timeout or 60
+                )
+                response.raise_for_status()
+                
+            except Exception as e:
+                error_msg = f"Failed to fetch WTTJ jobs via Algolia API on page {page + 1}: {e}"
+                if 'response' in locals() and response.text:
+                    error_msg += f" | Details: {response.text}"
+                log.error(error_msg)
+                raise WttjException(error_msg)
+            
+            data = response.json()
+            hits = data.get("hits", [])
+            
+            if not hits:
+                log.info("WTTJ: No more jobs returned by the Algolia backend.")
+                break
+
+            for job in hits:
+                if len(job_list) >= scraper_input.results_wanted:
+                    break
+
+                slug = job.get("slug", "")
+                if not slug:
+                    continue
+
+                organization = job.get("organization") or {}
+                company_slug = organization.get("slug", "unknown")
+                
+                # Reconstruction immédiate de l'URL pour la validation d'unicité
+                full_job_url = f"https://www.welcometothejungle.com/fr/companies/{company_slug}/jobs/{slug}"
+
+                # Si l'URL a déjà été enregistrée (doublon d'indexation d'Algolia), on passe au suivant
+                if full_job_url in seen_urls:
+                    continue
+                seen_urls.add(full_job_url)
+
+                title = job.get("name", "Unknown Title")
+                company_name = organization.get("name", "Unknown Company")
+                
+                logo_dict = organization.get("logo") or {}
+                company_logo = logo_dict.get("url") if isinstance(logo_dict, dict) else None
+                
+                office = job.get("office") or {}
+                location_city = office.get("city")
+                location_country = office.get("country_code") or office.get("country")
+                
+                is_remote = job.get("remote") in ["full", "partial"] or job.get("workplace_type") == "remote"
+                parsed_job_types = _map_wttj_job_type(job.get("contract_type"))
+                date_posted = _parse_date(job.get("published_at") or job.get("created_at"))
+                
+                job_id = str(job.get("objectID") or job.get("id") or f"wttj-{abs(hash(slug))}")
+
+                job_list.append(JobPost(
+                    id=job_id,
+                    title=title,
+                    company_name=company_name,
+                    job_url=full_job_url,
+                    location=Location(city=location_city, country=location_country),
+                    is_remote=is_remote,
+                    job_type=parsed_job_types,
+                    date_posted=date_posted,
+                    company_logo=company_logo,
+                ))
+                                    
+            page += 1
+
+        return JobResponse(jobs=job_list[:scraper_input.results_wanted])


### PR DESCRIPTION
### Description
This PR adds support for scraping jobs from **Welcome to the Jungle (WTTJ)**, a major job board in Europe/France.

### Key Features
- **Algolia API Backend Integration**: Uses the official public production Algolia index utilized by WTTJ (`wk_cms_jobs_production`), making queries incredibly fast and resilient.
- **Strict URL Deduplication**: Employs an explicit `seen_urls` set check across pages. This prevents adding identical postings that Algolia replicates with distinct ephemeral `objectIDs`.
- **Accurate Pagination**: Converts `scraper_input.offset` correctly into a 0-indexed page for Algolia.
- **Job Field Mapping**: Maps core WTTJ contracts (`full_time`, `part_time`, `internship`, `apprenticeship`, etc.) into JobSpy's standard `JobType` enum, along with robust date parsing.

### File Modifications
- `jobspy/wttj/__init__.py`: Implements the main `Wttj` Scraper class.
- `jobspy/model.py`: Registers `Site.WTTJ`.
- `jobspy/__init__.py`: Links `Wttj` within `SCRAPER_MAPPING` for asynchronous workers.
- `jobspy/exception.py`: Introduces `WttjException` for gracefully reporting errors.

Tested locally with different case and successfully find jobs in France.