### PR TITLE
Update Python version requirement in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 pip install -U python-jobspy
 ```
 
-_Python version >= [3.10](https://www.python.org/downloads/release/python-3100/) required_
+_Python version  [3.10](https://www.python.org/downloads/release/python-3100/) to [3.12](https://www.python.org/downloads/release/python-3120/) required_
 
 ### Usage
 


### PR DESCRIPTION
In the issue, I find a problem with the dependency with NumPy; the project works only on 3.10 to 3.12, so it's better to write clearly on 3.10 to 3.12. 

The issue im reffered :

Currently using on a project a python 3.14.6

i try to install the library from your standard pip:

`pip install -U python-jobspy
`
and this the error that appear:

```
pip install -U python-jobspy
Defaulting to user installation because normal site-packages is not writeable
Collecting python-jobspy
  Using cached python_jobspy-1.1.82-py3-none-any.whl.metadata (10 kB)
Collecting NUMPY==1.26.3 (from python-jobspy)
  Using cached numpy-1.26.3.tar.gz (15.7 MB)
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Installing backend dependencies ... done
  Preparing metadata (pyproject.toml) ... error
  error: subprocess-exited-with-error
  
  × Preparing metadata (pyproject.toml) did not run successfully.
  │ exit code: 1
  ╰─> [20 lines of output]
      + /usr/bin/python3 /tmp/pip-install-pyfx8aed/numpy_82ce509398a6473ba15e7e47d606088f/vendored-meson/meson/meson.py setup /tmp/pip-install-pyfx8aed/numpy_82ce509398a6473ba15e7e47d606088f /tmp/pip-install-pyfx8aed/numpy_82ce509398a6473ba15e7e47d606088f/.mesonpy-lnspuq12/build -Dbuildtype=release -Db_ndebug=if-release -Db_vscrt=md --native-file=/tmp/pip-install-pyfx8aed/numpy_82ce509398a6473ba15e7e47d606088f/.mesonpy-lnspuq12/build/meson-python-native-file.ini
      The Meson build system
      Version: 1.2.99
      Source dir: /tmp/pip-install-pyfx8aed/numpy_82ce509398a6473ba15e7e47d606088f
      Build dir: /tmp/pip-install-pyfx8aed/numpy_82ce509398a6473ba15e7e47d606088f/.mesonpy-lnspuq12/build
      Build type: native build
      Project name: NumPy
      Project version: 1.26.3
      
      ../../meson.build:1:0: ERROR: Unknown compiler(s): [['cc'], ['gcc'], ['clang'], ['nvc'], ['pgcc'], ['icc'], ['icx']]
      The following exception(s) were encountered:
      Running `cc --version` gave "[Errno 2] No such file or directory: 'cc'"
      Running `gcc --version` gave "[Errno 2] No such file or directory: 'gcc'"
      Running `clang --version` gave "[Errno 2] No such file or directory: 'clang'"
      Running `nvc --version` gave "[Errno 2] No such file or directory: 'nvc'"
      Running `pgcc --version` gave "[Errno 2] No such file or directory: 'pgcc'"
      Running `icc --version` gave "[Errno 2] No such file or directory: 'icc'"
      Running `icx --version` gave "[Errno 2] No such file or directory: 'icx'"
      
      A full log can be found at /tmp/pip-install-pyfx8aed/numpy_82ce509398a6473ba15e7e47d606088f/.mesonpy-lnspuq12/build/meson-logs/meson-log.txt
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed

× Encountered error while generating package metadata.
╰─> NUMPY
```

for try to resolve i switch to python 3.12 with a venv and use this command with uv:

`uv pip install -U python-jobspy`

that give me this:

```
Resolved 22 packages in 677ms
Prepared 14 packages in 3.57s
Installed 14 packages in 503ms
 + annotated-types==0.8.0
 + markdownify==0.13.1
 + numpy==1.26.3
 + pandas==2.3.3
 + pydantic==2.13.4
 + pydantic-core==2.46.4
 + python-dateutil==2.9.0.post0
 + python-jobspy==1.1.82
 + pytz==2026.3.post1
 + regex==2024.11.6
 + six==1.17.0
 + tls-client==1.0.1
 + typing-inspection==0.4.2
 + tzdata==2026.3
```
as you can see jobspy get installed and if i run this:

python -c "from jobspy import scrape_jobs; print('ok')"

it print ok so its install

i tried with and other version like the 3.13.14 and i got the main error on the top.

So i deep in and the main problem is that lib have depency on numpy= 1.26.3, now when im writing is 2.5.1,
as you can see on the lib version https://pypi.org/project/numpy/1.26.3/ the version of python for get thing work is max 3.12 that checks out the analyis did before.

So this project work only on 3.9( it refer to numpy, 3,10 for other depency tha idk) to 3.12 and only not up to 3.10.

Thanks for all the work i hope this get appreciated

Closes - #376
