### PR TITLE
fix(ziprecruiter): add country validation and warning for unsupported searches

### DIFF
--- a/jobspy/ziprecruiter/__init__.py
+++ b/jobspy/ziprecruiter/__init__.py
@@ -61,6 +61,12 @@ class ZipRecruiter(Scraper):
         :return: JobResponse containing a list of jobs.
         """
         self.scraper_input = scraper_input
+        if scraper_input.country not in (Country.USA, Country.CANADA, Country.US_CANADA):
+            log.warning(
+                "ZipRecruiter only supports US/Canada searches; skipping unsupported country search"
+            )
+            return JobResponse(jobs=[])
+
         job_list: list[JobPost] = []
         continue_token = None
 
@@ -100,10 +106,14 @@ class ZipRecruiter(Scraper):
             if res.status_code not in range(200, 400):
                 if res.status_code == 429:
                     err = "429 Response - Blocked by ZipRecruiter for too many requests"
+                elif res.status_code == 403:
+                    err = (
+                        "ZipRecruiter response status code 403; skipping blocked or unsupported search"
+                    )
                 else:
                     err = f"ZipRecruiter response status code {res.status_code}"
                     err += f" with response: {res.text}"  # ZipRecruiter likely not available in EU
-                log.error(err)
+                log.warning(err)
                 return jobs_list, ""
         except Exception as e:
             if "Proxy responded with" in str(e):


### PR DESCRIPTION
This pull request improves the robustness and clarity of the ZipRecruiter scraper by adding better handling for unsupported countries and certain HTTP error codes. The main changes ensure that searches are only attempted for supported countries (USA and Canada), and that clearer warnings are logged for blocked or unsupported searches.

**Geographic restrictions:**
* Updated the `scrape` method in `jobspy/ziprecruiter/__init__.py` to check if the requested country is supported (USA or Canada). If not, a warning is logged and an empty result is returned.

**Error handling and logging:**
* Improved HTTP error handling in `_find_jobs_in_page` by adding a specific warning for 403 responses (blocked or unsupported searches) and changing error logs to warnings for better clarity.