### PR TITLE
fix(glassdoor): 400 location not parsed error

### DIFF
--- a/jobspy/model.py
+++ b/jobspy/model.py
@@ -162,7 +162,7 @@ class Country(Enum):
             raise Exception(f"Glassdoor is not available for {self.name}")
 
     def get_glassdoor_url(self):
-        return f"https://{self.glassdoor_domain_value}/"
+        return f"https://{self.glassdoor_domain_value}"
 
     @classmethod
     def from_string(cls, country_str: str):


### PR DESCRIPTION
The resolved URL: `https://www.glassdoor.co.in//findPopularLocationAjax.htm?maxLocationsToReturn=10&term=Delhi` because during the `locatinon_url` construction two forward slashes are being added to url:

In `glassdoor/__init__.py` we are adding **"/"** after `self.base_url`:

`url = f"{self.base_url}/findPopularLocationAjax.htm?maxLocationsToReturn=10&term={location}"`

and in `models.py` when building the `base_url` we are again adding a **"/"** at the end:

```python
def get_glassdoor_url(self):
        return f"https://{self.glassdoor_domain_value}/"
```

Thus, the requests fails.

## Fix:

Just remove the "/" from one place:

```python
def get_glassdoor_url(self):
        return f"https://{self.glassdoor_domain_value}"
```